### PR TITLE
Standalone: Fix some ignored directories in the standard lib path.

### DIFF
--- a/nuitka/freezer/Standalone.py
+++ b/nuitka/freezer/Standalone.py
@@ -361,7 +361,7 @@ def scanStandardLibraryPath(stdlib_dir):
                 dirs.remove("ensurepip")
 
             # Ignore "lib-dynload" and "lib-tk" and alikes.
-            dirs = [
+            dirs[:] = [
                 dirname
                 for dirname in
                 dirs


### PR DESCRIPTION
Before, these directories themselves wouldn't be returned from scanStandardLibraryPath, but they would still be recursively explored. Now, the list contents are replaced in-place, so the contents of these directories are excluded from the walk.

I was having the same issue as http://bugs.nuitka.net/issue292 with the latest version. The "Tools" directory wasn't directly returned, but all the actual scripts inside it still were. This fixes that by modifying the list in-place so it affects the rest of the os.walk.