### PR TITLE
Update MemoryUsage.py

### DIFF
--- a/nuitka/utils/MemoryUsage.py
+++ b/nuitka/utils/MemoryUsage.py
@@ -30,6 +30,7 @@ def getOwnProcessMemoryUsage():
     if getOS() == "Windows":
         # adapted from http://code.activestate.com/recipes/578513
         import ctypes
+        import ctypes.wintypes
 
         # Lets allow this to match Windows API it reflects,
         # pylint: disable=C0103


### PR DESCRIPTION
Fixes the following error with Python 2.7:
Traceback (most recent call last):
  File "C:\Python27\Scripts\nuitka", line 193, in <module>
    MainControl.main()
  File "C:\Python27\Lib\site-packages\nuitka\MainControl.py", line 690, in main
    filename = filename
  File "C:\Python27\Lib\site-packages\nuitka\MainControl.py", line 61, in createNodeTree
    is_main  = not Options.shallMakeModule()
  File "C:\Python27\Lib\site-packages\nuitka\tree\Building.py", line 1151, in buildModuleTree
    is_main     = is_main
  File "C:\Python27\Lib\site-packages\nuitka\tree\Building.py", line 1095, in createModuleTree
    memory_watch = MemoryUsage.MemoryWatch()
  File "C:\Python27\Lib\site-packages\nuitka\utils\MemoryUsage.py", line 109, in **init**
    self.start = getOwnProcessMemoryUsage()
  File "C:\Python27\Lib\site-packages\nuitka\utils\MemoryUsage.py", line 36, in getOwnProcessMemoryUsage
    class PROCESS_MEMORY_COUNTERS_EX(ctypes.Structure):
  File "C:\Python27\Lib\site-packages\nuitka\utils\MemoryUsage.py", line 38, in PROCESS_MEMORY_COUNTERS_EX
    ("cb", ctypes.wintypes.DWORD),
AttributeError: 'module' object has no attribute 'wintypes'
