### PR TITLE
Updates to bdist_nuitka

### DIFF
--- a/nuitka/distutils/bdist_nuitka.py
+++ b/nuitka/distutils/bdist_nuitka.py
@@ -31,6 +31,15 @@ import wheel.bdist_wheel  # @UnresolvedImport
 # pylint: disable=C0103
 class bdist_nuitka(wheel.bdist_wheel.bdist_wheel):
 
+    def finalize_options(self):
+        # self.distribution.libraries = [[True]]
+        self.distribution.has_ext_modules = lambda: True
+
+        super(bdist_nuitka, self).finalize_options()
+        # Force module to be recognised as binary rather than pure python
+        self.root_is_pure = False
+        self.plat_name_supplied = self.plat_name is not None
+
     # Our wheel base class is very unpure, so are we
     # pylint: disable=attribute-defined-outside-init
     def run(self):
@@ -47,12 +56,11 @@ class bdist_nuitka(wheel.bdist_wheel.bdist_wheel):
         # Nuitka wants the main package by filename, probably we should stop
         # needing that.
         from nuitka.importing.Importing import findModule, setMainScriptDirectory
-        from nuitka.utils.Execution import getExecutablePath
 
         old_dir = os.getcwd()
         os.chdir(build_lib)
 
-        # Search in the build directory preferrably.
+        # Search in the build directory preferably.
         setMainScriptDirectory('.')
 
         package, main_filename, finding = findModule(
@@ -67,14 +75,26 @@ class bdist_nuitka(wheel.bdist_wheel.bdist_wheel):
         assert finding == "absolute", finding
         assert package is None, package
 
+        # If there are other files left over in the wheel after python scripts
+        # are compiled, we'll keep the folder structure with the files in the wheel
+        keep_resources = False
+
+        python_files = []
         recurse_packages = self.compile_packages.copy()
-        if os.path.isdir(self.main_package):
+        if os.path.isdir(main_filename):
             # Include all python files in wheel
-            for root, dirs, files in os.walk(self.main_package):
-                for fn in fnmatch.filter(files, '*.py'):
-                    module = os.path.join(root, fn)[:-3] if fn != '__init__.py' else root
-                    pypath = ".".join(module.split(os.sep))
-                    recurse_packages.append(pypath)
+            for root, dirs, files in os.walk(main_filename):
+                for fn in files:
+                    if fnmatch.fnmatch(fn, '*.py'):
+                        relpath = os.path.relpath(os.path.join(root, fn), os.path.dirname(main_filename))
+                        module = relpath[:-3] if fn != '__init__.py' else os.path.basename(root)
+                        pypath = ".".join(module.split(os.sep))
+                        recurse_packages.append(pypath)
+                        python_files.append(os.path.join(root, fn))
+                    else:
+                        keep_resources = True
+
+        output_dir = build_lib
 
         nuitka_binary = getExecutablePath("nuitka")
         if nuitka_binary is None:
@@ -85,7 +105,7 @@ class bdist_nuitka(wheel.bdist_wheel.bdist_wheel):
             nuitka_binary,
             "--module",
             "--plugin-enable=pylint-warnings",
-            "--output-dir=%s" % build_lib,
+            "--output-dir=%s" % output_dir,
             "--recurse-dir=%s" % self.main_package,
             "--recurse-not-to=*.tests",
             "--show-modules",
@@ -100,29 +120,32 @@ class bdist_nuitka(wheel.bdist_wheel.bdist_wheel):
 
         self.build_lib = build_lib
 
+        if keep_resources:
+            # Delete the individual source files and add new __init__ stub
+            for fn in python_files:
+                os.unlink(fn)
+        else:
+            # Delete the source copy of the module
+            shutil.rmtree(os.path.join(self.build_lib, self.main_package))
+
     def run_command(self, command):
-        # Force module to be recognised as binary rather than pure python
-        self.root_is_pure = False
-        self.plat_name_supplied = self.plat_name is not None
+        if command == "install":
+            command_obj = self.distribution.get_command_obj("install_lib")
+            setattr(command_obj, "install_dir", self.bdist_dir)
 
         result = super(bdist_nuitka, self).run_command(command)
 
         # After building, we are ready to build the extension module, from
-        # what "build_py" command has done.
+        # the folder what "build_py" command has assembled for us.
         if command == "build":
             command_obj = self.distribution.get_command_obj(command)
             command_obj.ensure_finalized()
 
             self._buildPackage(os.path.abspath(command_obj.build_lib))
 
-            # Delete the source copy of the module
-            shutil.rmtree(os.path.join(self.build_lib, self.main_package))
-
         return result
 
     def write_wheelfile(self, wheelfile_base, generator = None):
-        self.root_is_pure = False
-
         if generator is None:
             from nuitka.Version import getNuitkaVersion
             generator = "Nuitka (%s)" % getNuitkaVersion()

--- a/nuitka/distutils/bdist_nuitka.py
+++ b/nuitka/distutils/bdist_nuitka.py
@@ -97,10 +97,6 @@ class bdist_nuitka(wheel.bdist_wheel.bdist_wheel):
         self.root_is_pure = False
         self.plat_name_supplied = self.plat_name is not None
 
-        if command == "install":
-            # Delete the source copy of the module
-            shutil.rmtree(os.path.join(self.build_lib, self.main_package))
-
         result = super(bdist_nuitka, self).run_command(command)
 
         # After building, we are ready to build the extension module, from
@@ -110,6 +106,9 @@ class bdist_nuitka(wheel.bdist_wheel.bdist_wheel):
             command_obj.ensure_finalized()
 
             self._buildPackage(os.path.abspath(command_obj.build_lib))
+
+            # Delete the source copy of the module
+            shutil.rmtree(os.path.join(self.build_lib, self.main_package))
 
         return result
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@
 import os
 import sys
 from distutils.command.install_scripts import install_scripts
-from distutils.core import setup
+from setuptools import setup
 
 os.chdir(os.path.dirname(__file__) or '.')
 
@@ -293,4 +293,9 @@ setup(
     description  = """\
 Python compiler with full language support and CPython compatibility""",
     keywords     = "compiler,python,nuitka",
+    entry_points = {"distutils.commands": [
+                            'bdist_nuitka = \
+                             nuitka.distutils.bdist_nuitka:bdist_nuitka'
+                        ]
+                   },
 )

--- a/setup.py
+++ b/setup.py
@@ -294,8 +294,12 @@ setup(
 Python compiler with full language support and CPython compatibility""",
     keywords     = "compiler,python,nuitka",
     entry_points = {"distutils.commands": [
-                            'bdist_nuitka = \
-                             nuitka.distutils.bdist_nuitka:bdist_nuitka'
-                        ]
+                        'bdist_nuitka = \
+                         nuitka.distutils.bdist_nuitka:bdist_nuitka'
+                    ],
+                    "distutils.setup_keywords": [
+                        'build_with_nuitka = \
+                         nuitka.distutils.bdist_nuitka:setuptools_build_hook'
+                    ]
                    },
 )


### PR DESCRIPTION
I'm really excited about this usage of nuitka, it provides a very clean and controlled output being able to produce fully compiled wheels ready to distribute and install.

I'd actually started making my own module to integrate nuitka into setuptools before I found what you already had built in.

I've been testing/using this on windows, however this PR doesn't work as is on windows due to `getExecutablePath("nuitka")` failing in my virtualenv. I've been using this branch rebased on #36 where it all works perfectly.

Contents of PR:

* My initial tests of bdist_nuitka resulted in broken wheels with incorrect paths inside the wheel package.
For example, on my pc the package I'm compiling is `C:\Users\anl\src\example_package\setup.py`
When I built the wheel and then open is as a zip there was a deep folder structure inside it like 
`zip:\Users\anl\src\example_package\.venv\lib\site-packages\example_package.pyd`.  
I found all the stuff starting at line 96 in the install phase was unnecessary once the wheel class was pre-informed of it being a binary module and `self._buildPackage` was called with an absolute path.

* I regularly find issues compiling packages with python files not being included due to them not being explicitly imported by other files in the package. 
The changes starting with `recurse_packages` is designed to get around this by compiling and including all python files in the wheel. The actual nuitka compiling is done against the files that have been staged for building the wheel so the normal methods of setuptools to include the correct files in the wheel are observed.
This doesn't yet do anything to work around the issues with other resources/files that would have been included in the wheel, these are still deleted along with the source. I'd like to resolve this but that will be a follow up pr.

* The final change in `setup.py` registers the `bdist_nuitka` command when nuitka is installed so you no longer need to explicitly reference the module when running.
old: `python setup.py --command-packages=nuitka.distutils clean -a bdist_nuitka`
new: `python setup.py bdist_nuitka`