### PR TITLE
Fix getExecutablePath() to return path instead of bool

### DIFF
--- a/nuitka/build/SingleExe.scons
+++ b/nuitka/build/SingleExe.scons
@@ -201,7 +201,7 @@ def getExecutablePath(filename, initial):
     """ Find an execute in either normal PATH, or Scons detected PATH. """
 
     if os.path.exists(filename):
-        return True
+        return filename
 
     # Variable substitution from environment is needed, because this can contain
     # "$CC" which should be looked up too.


### PR DESCRIPTION
When full path to compiler was provided by CC env var with --show-scons I got:
Scons compiler: Using True