### PR TITLE
Fix compiling with provided GCC through CC env var

### DIFF
--- a/nuitka/build/SingleExe.scons
+++ b/nuitka/build/SingleExe.scons
@@ -429,6 +429,7 @@ if "CC" in os.environ:
     # If the environment variable CXX is set, use that.
     env["CC"] = os.environ["CC"]
     env["CCVERSION"] = None
+    found_gcc = True
 elif clang_mode:
     # If requested by the user, use the clang compiler, overriding what was
     # said in environment.


### PR DESCRIPTION
If system had too old (default) GCC found_gcc is set to False,
so if another compiler was provided with CC Nuitka used g++ instead.