### PR TITLE
Remove obsolete nuitka binary search

### DIFF
--- a/nuitka/distutils/bdist_nuitka.py
+++ b/nuitka/distutils/bdist_nuitka.py
@@ -97,10 +97,6 @@ class build(distutils.command.build.build):
 
         output_dir = build_lib
 
-        nuitka_binary = getExecutablePath("nuitka")
-        if nuitka_binary is None:
-            sys.exit("Error, cannot find nuitka binary in PATH.")
-
         command = [
             sys.executable,
             "-m", "nuitka",


### PR DESCRIPTION
I found a merge-fail left over from my previous couple of merge requests, #38 and #36. 
Currently bdist_nuitka fails as it's searching for the binary which was removed in #36

This PR removed the check which is already no longer used.