### PR TITLE
bdist_nuitka: Allow passing extra nuitka options from setup.py

### DIFF
--- a/nuitka/distutils/bdist_nuitka.py
+++ b/nuitka/distutils/bdist_nuitka.py
@@ -25,6 +25,8 @@ import os
 import shutil
 import subprocess
 import sys
+import collections
+from nuitka.__past__ import unicode
 
 import wheel.bdist_wheel  # @UnresolvedImport pylint: disable=I0021,import-error,no-name-in-module
 
@@ -110,6 +112,7 @@ class build(distutils.command.build.build):
             "--output-dir=%s" % output_dir,
             "--recurse-dir=%s" % self.main_package,
             "--recurse-to=%s" % self.main_package,
+            "--recurse-not-to=*.tests",
             "--show-modules",
             "--remove-output"
         ]
@@ -121,7 +124,8 @@ class build(distutils.command.build.build):
                 source, value = details
                 if value is None:
                     command.append(option)
-                elif hasattr(value, '__iter__'):
+                elif isinstance(value, collections.Iterable) and \
+                        not isinstance(value, (unicode, bytes, str)):
                     for val in value:
                         command.append('%s=%s' % (option, val))
                 else:

--- a/nuitka/distutils/bdist_nuitka.py
+++ b/nuitka/distutils/bdist_nuitka.py
@@ -110,14 +110,27 @@ class build(distutils.command.build.build):
             "--output-dir=%s" % output_dir,
             "--recurse-dir=%s" % self.main_package,
             "--recurse-to=%s" % self.main_package,
-            "--recurse-not-to=*.tests",
             "--show-modules",
-            "--remove-output",
-            main_filename,
+            "--remove-output"
         ]
 
+        # Process any extra options from setuptools
+        if 'nuitka' in self.distribution.command_options:
+            for option, details in self.distribution.command_options['nuitka'].items():
+                option = "--" + option.lstrip('-')
+                source, value = details
+                if value is None:
+                    command.append(option)
+                elif hasattr(value, '__iter__'):
+                    for val in value:
+                        command.append('%s=%s' % (option, val))
+                else:
+                    command.append('%s=%s' % (option, value))
+
+        command.append(main_filename)
+
         subprocess.check_call(
-            command
+            command, cwd=build_lib
         )
         os.chdir(old_dir)
 


### PR DESCRIPTION
Adds the ability to pass any extra options to nuitka when used in bdist_nuitka.

Eg:
`setup.py`
```
from setuptools import setup

setup(
    name='mypackage',
    packages=['mypackage']
    options={
        'nuitka': {'recurse-not-to': ['mypackage.ui.assays'],
                   'plugin-enable': ['qt-plugins'],
                   'no-pyi-file': None}
    },
    build_with_nuitka=True
)
```

TODO: Documentation update is still required