### PR TITLE
Fix/cleanup builtins (for pypy3)

### DIFF
--- a/nuitka/Builtins.py
+++ b/nuitka/Builtins.py
@@ -119,7 +119,7 @@ def _getBuiltinNames():
 
 builtin_names, builtin_warnings = _getBuiltinNames()
 builtin_named_values = dict(
-    ((getattr(builtins, x), x)
+    (getattr(builtins, x), x)
     for x in builtin_names
 )
 builtin_named_values_list = tuple(builtin_named_values)

--- a/nuitka/Builtins.py
+++ b/nuitka/Builtins.py
@@ -27,9 +27,9 @@ from nuitka.__past__ import iterItems
 from nuitka.PythonVersions import python_version
 
 if str is bytes:
-    import __builtin__ as builtins
+    import __builtin__ as builtins  # @UnresolvedImport pylint: disable=I0021,import-error
 else:
-    import builtins
+    import builtins  # @UnresolvedImport pylint: disable=I0021,import-error
 
 
 def _getBuiltinExceptionNames():

--- a/nuitka/specs/BuiltinParameterSpecs.py
+++ b/nuitka/specs/BuiltinParameterSpecs.py
@@ -27,6 +27,11 @@ from nuitka.PythonVersions import python_version
 
 from .ParameterSpecs import ParameterSpec, TooManyArguments, matchCall
 
+if str is bytes:
+    import __builtin__ as builtins
+else:
+    import builtins
+
 
 class BuiltinParameterSpec(ParameterSpec):
     __slots__ = ("builtin",)
@@ -43,7 +48,7 @@ class BuiltinParameterSpec(ParameterSpec):
             ps_kw_only_args  = ()
         )
 
-        self.builtin = __builtins__[name]
+        self.builtin = getattr(builtins, name)
 
         assert default_count <= len(arg_names)
 

--- a/nuitka/specs/BuiltinParameterSpecs.py
+++ b/nuitka/specs/BuiltinParameterSpecs.py
@@ -28,9 +28,9 @@ from nuitka.PythonVersions import python_version
 from .ParameterSpecs import ParameterSpec, TooManyArguments, matchCall
 
 if str is bytes:
-    import __builtin__ as builtins
+    import __builtin__ as builtins  # @UnresolvedImport pylint: disable=I0021,import-error
 else:
-    import builtins
+    import builtins  # @UnresolvedImport pylint: disable=I0021,import-error
 
 
 class BuiltinParameterSpec(ParameterSpec):


### PR DESCRIPTION
This PR improves the compatibility to pypy and other compilers.
Instead of relying on \_\_builtins\_\_ beeing a dict it imports exceptions and other
builtin stuff from builtins or \_\_builtin\_\_ (python2)

Also it cleans up the \_getBuiltinExceptionNames function.

Note: pypy3 still fails for an other reason. 