### PR TITLE
Use feature detection to reduce PyLint clutter

### DIFF
--- a/nuitka/__past__.py
+++ b/nuitka/__past__.py
@@ -30,15 +30,15 @@ import sys
 # pylint: disable=I0021,invalid-name,redefined-builtin
 
 # Work around for CPython 3.x renaming "long" to "int".
-if str is bytes:
-    long = long  # @ReservedAssignment pylint: disable=I0021,undefined-variable
-else:
+try:
+    long = long  # @ReservedAssignment
+except NameError:
     long = int   # @ReservedAssignment
 
 # Work around for CPython 3.x renaming "unicode" to "str".
-if str is bytes:
-    unicode = unicode  # @ReservedAssignment pylint: disable=I0021,undefined-variable
-else:
+try:
+    unicode = unicode  # @ReservedAssignment
+except NameError:
     unicode = str      # @ReservedAssignment
 
 def iterItems(d):
@@ -47,26 +47,25 @@ def iterItems(d):
     except AttributeError:
         return d.items()
 
-if str is not bytes:
-    raw_input = input      # @ReservedAssignment
-else:
+try:
     raw_input = raw_input  # @ReservedAssignment
+except NameError:
+    raw_input = input      # @ReservedAssignment
 
-if str is bytes:
-    xrange = xrange # @ReservedAssignment pylint: disable=I0021,undefined-variable
-else:
-    xrange = range  # @ReservedAssignment
+try:
+    xrange = xrange  # @ReservedAssignment
+except NameError:
+    xrange = range   # @ReservedAssignment
 
+try:
+    from urllib.request import urlretrieve  # @UnresolvedImport pylint: disable=I0021
+except ImportError:
+    from urllib import urlretrieve          # @UnresolvedImport pylint: disable=I0021
 
-if str is bytes:
-    from urllib import urlretrieve # @UnresolvedImport pylint: disable=I0021,import-error,no-name-in-module
-else:
-    from urllib.request import urlretrieve # @UnresolvedImport pylint: disable=I0021,import-error,no-name-in-module
-
-if str is bytes:
-    from cStringIO import StringIO # @UnresolvedImport pylint: disable=I0021,import-error
-else:
-    from io import StringIO # @UnresolvedImport pylint: disable=I0021,import-error
+try:
+    from cStringIO import StringIO  # @UnresolvedImport pylint: disable=I0021
+except ImportError:
+    from io import StringIO         # @UnresolvedImport pylint: disable=I0021
 
 try:
     from functools import total_ordering
@@ -81,9 +80,9 @@ except ImportError:
 
         return cls
 
-if str is bytes:
-    intern = intern      # @ReservedAssignment pylint: disable=I0021,undefined-variable
-else:
+try:
+    intern = intern      # @ReservedAssignment
+except NameError:
     intern = sys.intern  # @ReservedAssignment @UndefinedVariable
 
 # For PyLint to be happy.

--- a/nuitka/__past__.py
+++ b/nuitka/__past__.py
@@ -58,14 +58,14 @@ except NameError:
     xrange = range   # @ReservedAssignment
 
 try:
-    from urllib.request import urlretrieve  # @UnresolvedImport pylint: disable=I0021
+    from urllib.request import urlretrieve  # @UnresolvedImport
 except ImportError:
-    from urllib import urlretrieve          # @UnresolvedImport pylint: disable=I0021
+    from urllib import urlretrieve          # @UnresolvedImport
 
 try:
-    from cStringIO import StringIO  # @UnresolvedImport pylint: disable=I0021
+    from cStringIO import StringIO  # @UnresolvedImport
 except ImportError:
-    from io import StringIO         # @UnresolvedImport pylint: disable=I0021
+    from io import StringIO         # @UnresolvedImport
 
 try:
     from functools import total_ordering

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,5 +1,5 @@
 # PyLint wouldn't be installable on 2.6 and not work with 3.3
 
 pylint == 1.9.3 ; python_version == '2.7'
-pylint == 2.0.0 ; python_version >= '3.4'
-astroid == 2.0.0 ; python_version >= '3.4'
+pylint == 2.1.1 ; python_version >= '3.4'
+astroid >= 2.0.0 ; python_version >= '3.4'

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,5 +1,5 @@
 # PyLint wouldn't be installable on 2.6 and not work with 3.3
 
 pylint == 1.9.3 ; python_version == '2.7'
-pylint == 2.1.1 ; python_version >= '3.4'
-astroid >= 2.0.0 ; python_version >= '3.4'
+pylint == 2.0.0 ; python_version >= '3.4'
+astroid == 2.0.0 ; python_version >= '3.4'


### PR DESCRIPTION
The Python porting best practice is to [use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).  The __try / except (ImportError, NameError)__ approach proposed in this PR __placates the linters PyLint and flake8__ while substantially reducing the comment clutter of disable directives.  The __assert__ statements at the end also probably not necessary anymore but this PR leaves them in place.

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md

### What does this PR do?

### Why was it initiated? Any relevant Issues?

### PR Checklist
- [x] Correct base branch selected? `develop` for new fetures and bug fixes too. If it's
      part of a hotfix, it will be moved to ``master`` during it.
- [ ] All tests still pass. Check the developer manual about ``Running the Tests``. There
      are Travis tests that cover the most important things however, you are welcome
      to rely on those.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documention updates.
