### PR TITLE
gitignore: ignore Mac OS directory cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+*.DS_Store
 *.e4t
 *.e4q
 *.e4s


### PR DESCRIPTION
Added a line to the .gitignore file in order to ignore Mac OS directory cache data.