### PR TITLE
nuitka: fixed output filename on Unix like platforms

### DIFF
--- a/nuitka/MainControl.py
+++ b/nuitka/MainControl.py
@@ -814,7 +814,10 @@ def main():
             sys.exit(0)
 
         if Options.isStandaloneMode():
-            binary_filename = options["result_name"] + ".exe"
+            if Utils.getOS() == "Windows":
+                binary_filename = options["result_name"] + ".exe"
+            else:
+                binary_filename = options["result_name"]
 
             standalone_entry_points.insert(
                 0,


### PR DESCRIPTION
Fixes output executable filenames on Unix like platforms, executables on Windows end with the .exe extension while executables on a majority of Unix like operating systems have no file extension...