### PR TITLE
Fix #133, Visual Studio linker failing when dealing with a lot of obj…

### DIFF
--- a/nuitka/build/inline_copy/lib/scons-3.0.1/SCons/Platform/__init__.py
+++ b/nuitka/build/inline_copy/lib/scons-3.0.1/SCons/Platform/__init__.py
@@ -217,7 +217,7 @@ class TempFileMunge(object):
             prefix = '@'
 
         args = list(map(SCons.Subst.quote_spaces, cmd[1:]))
-        os.write(fd, bytearray(" ".join(args) + "\n",'utf-8'))
+        os.write(fd, bytearray("\n".join(args) + "\n",'utf-8'))
         os.close(fd)
         # XXX Using the SCons.Action.print_actions value directly
         # like this is bogus, but expedient.  This class should


### PR DESCRIPTION
No much more to say than what's already commented on #133 .

Feel free to review it and test it over there. In case you're making new suggestions make sure they're quite precisse as this one is quite hard to reproduce, I've had to create to some dummy packages automagically so the `link @whatever.rsp` appears... Sure there are better/faster ways to iterate about it but I'm not an SCons expert and I don't intend to become one, so... ;)